### PR TITLE
Redesign blog with slate/teal palette and improved mobile nav

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "blog",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-border">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6">
+      <div className="mx-auto max-w-4xl px-5 py-8 sm:px-6">
         <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <span className="text-sm text-muted-foreground">
             &copy; {new Date().getFullYear()} {siteMetadata.author}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ const Header = () => {
         scrolled ? "bg-background/90 backdrop-blur-md" : "bg-transparent"
       }`}
     >
-      <div className="mx-auto max-w-7xl px-4 sm:px-6">
+      <div className="mx-auto max-w-4xl px-5 sm:px-6">
         <div className="flex items-center justify-between py-4 sm:py-5">
           <Link href="/" aria-label={siteMetadata.headerTitle}>
             <span className="text-lg font-semibold text-foreground">

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,140 +1,157 @@
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
+import { createPortal } from "react-dom"
 import Link from "./Link"
 import headerNavLinks from "@/config/headerNavLinks"
 import { Menu, X } from "lucide-react"
 
 const MobileNav = () => {
-  const [navShow, setNavShow] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
   const panelRef = useRef<HTMLDivElement>(null)
   const toggleRef = useRef<HTMLButtonElement>(null)
 
-  const onToggleNav = () => {
-    setNavShow((status) => {
-      document.body.style.overflow = status ? "auto" : "hidden"
-      return !status
-    })
-  }
+  useEffect(() => setMounted(true), [])
 
-  const closeNav = () => {
-    setNavShow(false)
-    document.body.style.overflow = "auto"
+  const close = useCallback(() => {
+    setOpen(false)
+    document.body.style.overflow = ""
     toggleRef.current?.focus()
-  }
+  }, [])
 
-  // Focus trap inside the panel
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      document.body.style.overflow = prev ? "" : "hidden"
+      return !prev
+    })
+  }, [])
+
+  // Focus trap + keyboard handling
   useEffect(() => {
-    if (!navShow || !panelRef.current) return
+    if (!open || !panelRef.current) return
     const panel = panelRef.current
     const focusables = panel.querySelectorAll<HTMLElement>(
-      'a[href], button, input, textarea, select, [tabindex]:not([tabindex="-1"])'
+      'a[href], button, [tabindex]:not([tabindex="-1"])'
     )
     if (focusables.length > 0) focusables[0].focus()
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { closeNav(); return }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        close()
+        return
+      }
       if (e.key !== "Tab" || focusables.length === 0) return
       const first = focusables[0]
       const last = focusables[focusables.length - 1]
       if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault(); last.focus()
+        e.preventDefault()
+        last.focus()
       } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault(); first.focus()
+        e.preventDefault()
+        first.focus()
       }
     }
-    document.addEventListener("keydown", handleKeyDown)
-    return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [navShow])
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [open, close])
 
+  // Close on resize to desktop
   useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth >= 768 && navShow) closeNav()
+    const onResize = () => {
+      if (window.innerWidth >= 768 && open) close()
     }
-    window.addEventListener("resize", handleResize)
-    return () => window.removeEventListener("resize", handleResize)
-  }, [navShow])
+    window.addEventListener("resize", onResize)
+    return () => window.removeEventListener("resize", onResize)
+  }, [open, close])
 
+  // Cleanup on unmount
   useEffect(() => {
-    return () => { document.body.style.overflow = "auto" }
+    return () => {
+      document.body.style.overflow = ""
+    }
   }, [])
+
+  const navLinks = headerNavLinks.filter((link) => link.href !== "/")
+
+  const overlay = (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Navigation menu"
+      className={`fixed inset-0 z-[100] md:hidden transition-opacity duration-200 ${
+        open ? "opacity-100" : "pointer-events-none opacity-0"
+      }`}
+    >
+      {/* Full-screen backdrop */}
+      <div
+        className="absolute inset-0 bg-background/95 backdrop-blur-lg"
+        onClick={close}
+        aria-hidden="true"
+      />
+
+      {/* Content */}
+      <div className="relative flex h-dvh flex-col">
+        {/* Close button */}
+        <div className="flex justify-end px-5 py-4">
+          <button
+            aria-label="Close menu"
+            onClick={close}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:text-foreground"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Nav links — centered */}
+        <nav className="flex flex-1 flex-col items-start justify-center px-10">
+          <div className="space-y-2">
+            {navLinks.map((link, i) => {
+              const cls =
+                "block text-2xl font-display font-semibold tracking-tight text-foreground/80 transition-colors duration-150 hover:text-accent py-2"
+
+              return link.track ? (
+                <a
+                  key={link.title}
+                  href={link.href}
+                  className={cls}
+                  style={{ animationDelay: `${i * 50}ms` }}
+                  data-umami-event={`mobile_header_${link.title.toLowerCase()}`}
+                  onClick={close}
+                >
+                  {link.title}
+                </a>
+              ) : (
+                <Link
+                  key={link.title}
+                  href={link.href}
+                  className={cls}
+                  style={{ animationDelay: `${i * 50}ms` }}
+                  onClick={close}
+                >
+                  {link.title}
+                </Link>
+              )
+            })}
+          </div>
+        </nav>
+      </div>
+    </div>
+  )
 
   return (
     <>
       <button
         ref={toggleRef}
         aria-label="Open menu"
-        aria-expanded={navShow}
-        onClick={onToggleNav}
-        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 md:hidden"
+        aria-expanded={open}
+        onClick={toggle}
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:text-accent md:hidden"
       >
         <Menu className="h-5 w-5" />
       </button>
 
-      {/* Backdrop */}
-      <div
-        className={`fixed inset-0 z-50 bg-black/40 transition-opacity duration-200 md:hidden ${
-          navShow ? "opacity-100" : "pointer-events-none opacity-0"
-        }`}
-        onClick={closeNav}
-        aria-hidden="true"
-      />
-
-      {/* Panel */}
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Navigation menu"
-        className={`fixed right-0 top-0 z-50 flex h-full w-72 max-w-[85vw] flex-col bg-background shadow-2xl transition-transform duration-200 ease-out md:hidden ${
-          navShow ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-border px-6 py-5">
-          <span className="text-lg font-semibold text-foreground">
-            Menu
-          </span>
-          <button
-            aria-label="Close Menu"
-            onClick={closeNav}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* Navigation */}
-        <nav className="flex-1 overflow-y-auto px-6 py-6">
-          <div className="space-y-1">
-            {headerNavLinks
-              .filter((link) => link.href !== "/")
-              .map((link) => {
-                const cls =
-                  "block rounded-lg px-3 py-2.5 text-base font-medium text-muted-foreground transition-colors duration-150 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-
-                return link.track ? (
-                  <a
-                    key={link.title}
-                    href={link.href}
-                    className={cls}
-                    data-umami-event={`mobile_header_${link.title.toLowerCase()}`}
-                    onClick={closeNav}
-                  >
-                    {link.title}
-                  </a>
-                ) : (
-                  <Link
-                    key={link.title}
-                    href={link.href}
-                    className={cls}
-                    onClick={closeNav}
-                  >
-                    {link.title}
-                  </Link>
-                )
-              })}
-          </div>
-        </nav>
-      </div>
+      {/* Portal overlay to body — avoids backdrop-blur containing block */}
+      {mounted && createPortal(overlay, document.body)}
     </>
   )
 }

--- a/src/components/SectionContainer.tsx
+++ b/src/components/SectionContainer.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function SectionContainer({ children }: Props) {
   return (
-    <section className="mx-auto max-w-7xl px-4 sm:px-6">
+    <section className="mx-auto max-w-4xl px-5 sm:px-6">
       {children}
     </section>
   )

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -25,44 +25,38 @@ const PostItem = ({
 }: PostItemProps) => {
   return (
     <Link to="/posts/$" params={{ _splat: slug }} className="group block">
-      <article className="py-6">
-        <div className="flex items-center gap-3 text-sm text-muted-foreground">
-          <time dateTime={date}>{format(parseISO(date), "MMM d, yyyy")}</time>
-          {readingTime && (
-            <>
-              <span className="text-border">&middot;</span>
-              <span>{readingTime}</span>
-            </>
-          )}
-          {series && (
-            <>
-              <span className="text-border">&middot;</span>
-              <span className="text-accent">
-                {series}{part != null ? ` #${part}` : ""}
-              </span>
-            </>
-          )}
+      <article className="-mx-3 rounded-lg px-3 py-4 transition-colors duration-150 hover:bg-surface sm:-mx-4 sm:px-4 sm:py-5">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+          <h2 className="font-display text-lg font-semibold leading-snug tracking-tight text-foreground transition-colors duration-150 group-hover:text-accent sm:text-xl">
+            {title}
+          </h2>
+          <time
+            dateTime={date}
+            className="shrink-0 text-xs tabular-nums text-muted-foreground sm:text-sm"
+          >
+            {format(parseISO(date), "MMM d, yyyy")}
+          </time>
         </div>
-        <h2 className="mt-2 font-display text-xl font-semibold leading-snug tracking-tight text-foreground transition-colors duration-150 group-hover:text-accent sm:text-2xl">
-          {title}
-        </h2>
         {summary && (
-          <p className="mt-2 line-clamp-2 text-muted-foreground">
+          <p className="mt-1.5 line-clamp-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
             {summary}
           </p>
         )}
-        {tags.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {tags.slice(0, 4).map((tag) => (
-              <Tag key={tag} text={tag} asLink={false} />
-            ))}
-            {tags.length > 4 && (
-              <span className="text-sm text-muted-foreground">
-                +{tags.length - 4}
-              </span>
-            )}
-          </div>
-        )}
+        <div className="mt-2.5 flex flex-wrap items-center gap-2">
+          {series && (
+            <span className="text-xs font-medium text-accent">
+              {series}{part != null ? ` #${part}` : ""}
+            </span>
+          )}
+          {tags.slice(0, 3).map((tag) => (
+            <Tag key={tag} text={tag} asLink={false} />
+          ))}
+          {tags.length > 3 && (
+            <span className="text-xs text-muted-foreground">
+              +{tags.length - 3}
+            </span>
+          )}
+        </div>
       </article>
     </Link>
   )

--- a/src/layouts/EnhancedListLayout.tsx
+++ b/src/layouts/EnhancedListLayout.tsx
@@ -80,7 +80,7 @@ export default function EnhancedListLayout({
   const hasActiveFilters = searchQuery || selectedTags.length > 0
 
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
       <div className="pb-8 pt-12 sm:pt-16">
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           {title}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -25,7 +25,7 @@ export const Route = createRootRoute({
         content:
           "Full-stack developer passionate about web technologies, microservices, and modern software development.",
       },
-      { name: "theme-color", content: "#231f1b" },
+      { name: "theme-color", content: "#1e2433" },
     ],
     links: [
       { rel: "stylesheet", href: appCss },

--- a/src/routes/about/index.tsx
+++ b/src/routes/about/index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/about/")({
 
 function AboutPage() {
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
       <div className="pb-8 pt-12 sm:pt-16">
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           About

--- a/src/routes/consulting/index.tsx
+++ b/src/routes/consulting/index.tsx
@@ -66,7 +66,7 @@ function ConsultingPage() {
   ]
 
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
       <div className="pb-8 pt-12 sm:pt-16">
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           Consulting Services

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,38 +23,43 @@ function HomePage() {
   const recentPosts = sortedPosts.slice(0, MAX_DISPLAY)
 
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
-      {/* Personal intro */}
-      <div className="pb-8 pt-12 sm:pt-16">
-        <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
-          Latest Posts
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
+      {/* Personal intro block */}
+      <div className="pb-10 pt-14 sm:pb-12 sm:pt-20">
+        <h1 className="font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Hey, I'm Anto<span className="text-accent">.</span>
         </h1>
-        <p className="mt-3 max-w-xl text-lg text-muted-foreground">
-          Software engineer sharing what I learn — from cloud infrastructure to
-          frontend frameworks and everything in between.
+        <p className="mt-4 max-w-lg text-base leading-relaxed text-muted-foreground sm:text-lg">
+          Full-stack engineer writing about cloud infrastructure, frontend
+          frameworks, .NET, and the things I learn along the way.
         </p>
       </div>
 
-      {/* Post list */}
+      {/* Recent posts */}
       {recentPosts.length > 0 && (
-        <div className="divide-y divide-border">
-          {recentPosts.map((post) => (
-            <PostItem
-              key={post.slug}
-              slug={post.slug}
-              date={new Date(post.date).toISOString()}
-              title={post.title}
-              summary={post.excerpt || ""}
-              tags={post.tags}
-              series={post.series ?? undefined}
-              part={post.part ?? undefined}
-            />
-          ))}
+        <div>
+          <h2 className="mb-6 text-xs font-semibold tracking-widest uppercase text-muted-foreground">
+            Recent Writing
+          </h2>
+          <div className="space-y-1">
+            {recentPosts.map((post) => (
+              <PostItem
+                key={post.slug}
+                slug={post.slug}
+                date={new Date(post.date).toISOString()}
+                title={post.title}
+                summary={post.excerpt || ""}
+                tags={post.tags}
+                series={post.series ?? undefined}
+                part={post.part ?? undefined}
+              />
+            ))}
+          </div>
         </div>
       )}
 
       {sortedPosts.length > MAX_DISPLAY && (
-        <div className="py-8">
+        <div className="py-10">
           <Link
             to="/posts"
             className="inline-flex items-center gap-2 text-sm font-medium text-accent transition-colors duration-150 hover:text-accent-hover"

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute("/projects/")({
 
 function ProjectsPage() {
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
       <div className="pb-8 pt-12 sm:pt-16">
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           Projects

--- a/src/routes/series/index.tsx
+++ b/src/routes/series/index.tsx
@@ -18,7 +18,7 @@ function SeriesPage() {
   const seriesGroups = useMemo(() => getAllSeries(), [])
 
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
       <div className="pb-8 pt-12 sm:pt-16">
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           Blog Series

--- a/src/routes/tags/index.tsx
+++ b/src/routes/tags/index.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/tags/")({
 function TagsPage() {
   const tagsWithCount = getTagsWithCount()
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6">
+    <div className="mx-auto max-w-4xl px-5 sm:px-6">
       <div className="pb-8 pt-12 sm:pt-16">
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           Tags

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,59 +1,59 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "@fontsource-variable/dm-sans";
+@import "@fontsource-variable/geist";
 @import "@fontsource-variable/fraunces";
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 
 .dark {
-  --background: oklch(0.14 0.005 60);
-  --surface: oklch(0.17 0.006 60);
-  --foreground: oklch(0.93 0.01 80);
-  --muted-foreground: oklch(0.55 0.01 60);
-  --border: oklch(0.25 0.005 60);
-  --accent: oklch(0.65 0.12 45);
-  --accent-hover: oklch(0.72 0.14 45);
-  --accent-muted: oklch(0.30 0.04 45);
-  --ring: oklch(0.65 0.12 45);
-  --input: oklch(0.25 0.005 60);
-  --card: oklch(0.17 0.006 60);
-  --card-foreground: oklch(0.93 0.01 80);
-  --popover: oklch(0.17 0.006 60);
-  --popover-foreground: oklch(0.93 0.01 80);
-  --primary: oklch(0.65 0.12 45);
-  --primary-foreground: oklch(0.14 0.005 60);
-  --secondary: oklch(0.25 0.005 60);
-  --secondary-foreground: oklch(0.93 0.01 80);
-  --muted: oklch(0.20 0.005 60);
+  --background: oklch(0.16 0.01 250);
+  --surface: oklch(0.19 0.012 250);
+  --foreground: oklch(0.93 0.008 220);
+  --muted-foreground: oklch(0.58 0.015 240);
+  --border: oklch(0.26 0.012 250);
+  --accent: oklch(0.70 0.12 175);
+  --accent-hover: oklch(0.78 0.13 175);
+  --accent-muted: oklch(0.25 0.04 175);
+  --ring: oklch(0.70 0.12 175);
+  --input: oklch(0.26 0.012 250);
+  --card: oklch(0.19 0.012 250);
+  --card-foreground: oklch(0.93 0.008 220);
+  --popover: oklch(0.19 0.012 250);
+  --popover-foreground: oklch(0.93 0.008 220);
+  --primary: oklch(0.70 0.12 175);
+  --primary-foreground: oklch(0.16 0.01 250);
+  --secondary: oklch(0.26 0.012 250);
+  --secondary-foreground: oklch(0.93 0.008 220);
+  --muted: oklch(0.22 0.01 250);
   --destructive: oklch(0.60 0.20 25);
 }
 
 :root:not(.dark) {
-  --background: oklch(0.97 0.005 60);
+  --background: oklch(0.98 0.004 240);
   --surface: oklch(1.0 0 0);
-  --foreground: oklch(0.18 0.005 60);
-  --muted-foreground: oklch(0.45 0.01 60);
-  --border: oklch(0.88 0.005 60);
-  --accent: oklch(0.50 0.14 45);
-  --accent-hover: oklch(0.45 0.16 45);
-  --accent-muted: oklch(0.92 0.03 45);
-  --ring: oklch(0.50 0.14 45);
-  --input: oklch(0.88 0.005 60);
+  --foreground: oklch(0.20 0.015 250);
+  --muted-foreground: oklch(0.48 0.015 240);
+  --border: oklch(0.90 0.008 240);
+  --accent: oklch(0.45 0.12 175);
+  --accent-hover: oklch(0.38 0.14 175);
+  --accent-muted: oklch(0.94 0.03 175);
+  --ring: oklch(0.45 0.12 175);
+  --input: oklch(0.90 0.008 240);
   --card: oklch(1.0 0 0);
-  --card-foreground: oklch(0.18 0.005 60);
+  --card-foreground: oklch(0.20 0.015 250);
   --popover: oklch(1.0 0 0);
-  --popover-foreground: oklch(0.18 0.005 60);
-  --primary: oklch(0.50 0.14 45);
-  --primary-foreground: oklch(0.97 0.005 60);
-  --secondary: oklch(0.93 0.005 60);
-  --secondary-foreground: oklch(0.18 0.005 60);
-  --muted: oklch(0.93 0.005 60);
+  --popover-foreground: oklch(0.20 0.015 250);
+  --primary: oklch(0.45 0.12 175);
+  --primary-foreground: oklch(0.98 0.004 240);
+  --secondary: oklch(0.94 0.006 240);
+  --secondary-foreground: oklch(0.20 0.015 250);
+  --muted: oklch(0.94 0.006 240);
   --destructive: oklch(0.55 0.22 25);
 }
 
 @theme inline {
-  --font-sans: 'DM Sans Variable', 'DM Sans', system-ui, sans-serif;
+  --font-sans: 'Geist Variable', 'Geist', system-ui, sans-serif;
   --font-display: 'Fraunces Variable', 'Fraunces', Georgia, serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
 
@@ -100,7 +100,7 @@
     @apply bg-background text-foreground antialiased;
   }
   ::selection {
-    background: oklch(0.65 0.12 45 / 0.3);
+    background: oklch(0.70 0.12 175 / 0.25);
   }
   :focus-visible {
     @apply outline-2 outline-offset-2 outline-accent;
@@ -133,7 +133,7 @@
     letter-spacing: -0.02em;
   }
   .prose :where(a):not(:where([class~="not-prose"] *)) {
-    text-decoration-color: oklch(0.65 0.12 45 / 0.4);
+    text-decoration-color: oklch(0.70 0.12 175 / 0.35);
     text-underline-offset: 3px;
     transition: text-decoration-color 150ms ease-out;
   }
@@ -142,44 +142,44 @@
   }
 }
 
-/* Syntax highlighting — Forge theme */
+/* Syntax highlighting — Tide theme */
 .dark {
-  --code-comment: oklch(0.45 0.01 60);
-  --code-keyword: oklch(0.72 0.12 30);
-  --code-string: oklch(0.72 0.10 145);
-  --code-function: oklch(0.78 0.10 70);
-  --code-number: oklch(0.72 0.12 55);
-  --code-operator: oklch(0.65 0.12 45);
-  --code-class: oklch(0.78 0.08 85);
-  --code-variable: oklch(0.82 0.06 220);
-  --code-punctuation: oklch(0.55 0.01 60);
-  --code-attr-name: oklch(0.72 0.10 55);
-  --code-attr-value: oklch(0.72 0.10 145);
-  --code-tag: oklch(0.72 0.12 30);
-  --code-inserted: oklch(0.72 0.10 145);
+  --code-comment: oklch(0.48 0.01 240);
+  --code-keyword: oklch(0.75 0.10 280);
+  --code-string: oklch(0.72 0.10 160);
+  --code-function: oklch(0.78 0.10 200);
+  --code-number: oklch(0.75 0.10 80);
+  --code-operator: oklch(0.70 0.12 175);
+  --code-class: oklch(0.78 0.08 100);
+  --code-variable: oklch(0.82 0.06 230);
+  --code-punctuation: oklch(0.55 0.01 240);
+  --code-attr-name: oklch(0.75 0.10 200);
+  --code-attr-value: oklch(0.72 0.10 160);
+  --code-tag: oklch(0.75 0.10 280);
+  --code-inserted: oklch(0.72 0.10 160);
   --code-deleted: oklch(0.65 0.15 25);
-  --code-changed: oklch(0.72 0.10 70);
-  --code-line-highlight: oklch(0.20 0.01 60);
-  --code-line-number: oklch(0.38 0.01 60);
+  --code-changed: oklch(0.75 0.10 200);
+  --code-line-highlight: oklch(0.22 0.012 250);
+  --code-line-number: oklch(0.40 0.01 240);
 }
 :root:not(.dark) {
-  --code-comment: oklch(0.50 0.01 60);
-  --code-keyword: oklch(0.45 0.14 320);
-  --code-string: oklch(0.42 0.12 145);
-  --code-function: oklch(0.45 0.12 45);
-  --code-number: oklch(0.48 0.14 55);
-  --code-operator: oklch(0.50 0.14 45);
-  --code-class: oklch(0.45 0.10 85);
-  --code-variable: oklch(0.42 0.08 220);
-  --code-punctuation: oklch(0.45 0.01 60);
-  --code-attr-name: oklch(0.48 0.12 55);
-  --code-attr-value: oklch(0.42 0.12 145);
-  --code-tag: oklch(0.45 0.14 320);
-  --code-inserted: oklch(0.42 0.12 145);
+  --code-comment: oklch(0.52 0.01 240);
+  --code-keyword: oklch(0.45 0.14 280);
+  --code-string: oklch(0.42 0.12 160);
+  --code-function: oklch(0.42 0.12 200);
+  --code-number: oklch(0.48 0.14 80);
+  --code-operator: oklch(0.45 0.12 175);
+  --code-class: oklch(0.45 0.10 100);
+  --code-variable: oklch(0.42 0.08 230);
+  --code-punctuation: oklch(0.48 0.01 240);
+  --code-attr-name: oklch(0.42 0.12 200);
+  --code-attr-value: oklch(0.42 0.12 160);
+  --code-tag: oklch(0.45 0.14 280);
+  --code-inserted: oklch(0.42 0.12 160);
   --code-deleted: oklch(0.50 0.18 25);
-  --code-changed: oklch(0.45 0.12 45);
-  --code-line-highlight: oklch(0.94 0.01 60);
-  --code-line-number: oklch(0.62 0.01 60);
+  --code-changed: oklch(0.42 0.12 200);
+  --code-line-highlight: oklch(0.95 0.008 240);
+  --code-line-number: oklch(0.62 0.01 240);
 }
 
 /* Token styles */


### PR DESCRIPTION
## Summary
- **New color palette**: Replaced warm amber/brown with cool slate + teal/emerald (dark & light modes), including a new "Tide" syntax highlighting theme
- **Typography**: Swapped body font from DM Sans to Geist; kept Fraunces for display headings
- **Homepage**: Personal greeting hero ("Hey, I'm Anto.") with "Recent Writing" section label
- **Mobile nav refactor**: Portaled overlay via `createPortal` to fix `backdrop-blur` containing block bug; redesigned as full-screen frosted overlay with centered serif links
- **Layout**: Narrowed content width from `max-w-7xl` to `max-w-4xl` for focused editorial feel
- **Post items**: Cleaner card-style blocks with date stacking on mobile

## Test plan
- [ ] Verify dark and light mode colors across homepage, posts list, and post detail pages
- [ ] Test mobile menu opens correctly after scrolling (the main bug this fixes)
- [ ] Test mobile menu navigation links work and close the overlay
- [ ] Verify desktop nav links remain visible and functional at various viewport widths
- [ ] Check syntax highlighting colors on a code-heavy post
- [ ] Confirm responsive layout at mobile (375px), tablet (768px), and desktop (1440px+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)